### PR TITLE
Add SearchApi to documentation

### DIFF
--- a/pages/docs/configuration/dotenv.mdx
+++ b/pages/docs/configuration/dotenv.mdx
@@ -469,6 +469,18 @@ See detailed instructions here: **[Google Search](/docs/configuration/tools/goog
   ]}
 />
 
+#### SearchApi
+
+**Description:** SearchApi is a robust real-time SERP API delivering structured data from a collection of search engines.
+
+**Environment Variables:**
+
+<OptionTable
+  options={[
+    ['SEARCHAPI_API_KEY', 'string', 'Your SearchApi API key.','SEARCHAPI_API_KEY='],
+  ]}
+/>
+
 #### SerpAPI
 
 **Description:** SerpApi is a real-time API to access Google search results (not as performant)

--- a/pages/docs/configuration/tools/index.mdx
+++ b/pages/docs/configuration/tools/index.mdx
@@ -36,6 +36,11 @@ description: Tools and Plugins setup instructions
   - A better solution for 'browsing' is planned but can't guarantuee when
   - This plugin is best used in combination with google so it doesn't hallucinate webpages to visit
 
+### SearchApi
+- An alternative to Google Search
+  - You can get an API key here: **[https://www.searchapi.io/](https://www.searchapi.io/)**
+  - Upon registration, you have free 100 queries.
+
 ### SerpAPI
 - An alternative to Google search but not as performant in my opinion
   - You can get an API key here: **[https://serpapi.com/dashboard](https://serpapi.com/dashboard)**


### PR DESCRIPTION
Added [SearchApi](https://www.searchapi.io/) Tool documentation.


SearchApi is committed to supporting open-source integrations. Please feel free to mention [@SebastjanPrachovskij](https://github.com/SebastjanPrachovskij) for any future PR reviews related to SearchApi. We would be glad to help.